### PR TITLE
Fix slug in app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "expo": {
     "name": "FluentQuest",
-    "slug": "-fluentquest",
+    "slug": "fluentquest",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",


### PR DESCRIPTION
## Summary
- remove leading hyphen from `expo.slug` in app.json

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f4e272068832b9953957c2ddf82c0